### PR TITLE
Update Amazon Corretto to version 25 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM amazoncorretto:21-alpine as builder
+FROM amazoncorretto:25-alpine AS builder
 WORKDIR application
 ARG JAR_FILE=target/openleap-gateway-exec.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM amazoncorretto:21-alpine
+FROM amazoncorretto:25-alpine
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./

--- a/src/main/java/io/openleap/gateway/config/KeycloakConfig.java
+++ b/src/main/java/io/openleap/gateway/config/KeycloakConfig.java
@@ -2,6 +2,7 @@ package io.openleap.gateway.config;
 
 import io.openleap.gateway.service.KeycloakDynamicClientRegistrationRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -53,7 +54,7 @@ public class KeycloakConfig {
     }
 
     @Bean
-    @Profile("client-registration.enabled")
+    @ConditionalOnBooleanProperty("client-registration.enabled")
     ReactiveClientRegistrationRepository keycloakDynamicClientRegistrationRepository() {
         var registrationDetails = new KeycloakDynamicClientRegistrationRepository.ClientRegistrationDetails(
                 eurekaInstanceConfigBean.getInstanceId(),


### PR DESCRIPTION
- Updated Amazon Corretto version from 21 to 25 in Dockerfile  
- Replaced `@Profile` with `ConditionalOnBooleanProperty` for `client-registration.enabled` to improve configuration flexibility and reduce unnecessary bean creation  
- Merged `master` into `feature/update-dependencies` to sync changes  

No additional changes were introduced.